### PR TITLE
feat: some physics symbols conceal rule

### DIFF
--- a/lua/latex-conceal/init.lua
+++ b/lua/latex-conceal/init.lua
@@ -20,6 +20,7 @@ local default_opts = {
     "math",
     "font",
     "delim",
+    "phy",
   },
   ft = { "tex", "latex", "markdown" },
 }

--- a/queries_config/latex/conceal_phy.scm
+++ b/queries_config/latex/conceal_phy.scm
@@ -1,0 +1,38 @@
+; physics conceal rules for LaTeX
+; \bra{a} -> |a> \ket{a} -> <a|
+; TODO: faster conceal rules for physics commands
+(generic_command
+  command: ((command_name) @cmd (#eq? @cmd "\\bra"))
+  (#has-ancestor? @cmd math_environment inline_formula displayed_equation)
+  (#set! priority 101)
+  (#set! conceal "|"))
+
+(generic_command
+  command: (command_name) @_cmd (#eq? @_cmd "\\bra")
+  arg: (curly_group "{" @open1)
+  (#has-ancestor? @open1 math_environment inline_formula displayed_equation)
+  (#set! conceal ""))
+
+(generic_command
+  command: (command_name) @_cmd (#eq? @_cmd "\\bra")
+  arg: (curly_group "}" @close1)
+  (#has-ancestor? @close1 math_environment inline_formula displayed_equation)
+  (#set! conceal ">"))
+
+(generic_command
+  command: ((command_name) @cmd (#eq? @cmd "\\ket"))
+  (#has-ancestor? @cmd math_environment inline_formula displayed_equation)
+  (#set! priority 101)
+  (#set! conceal "<"))
+
+(generic_command
+  command: (command_name) @_cmd (#eq? @_cmd "\\ket")
+  arg: (curly_group "{" @open1)
+  (#has-ancestor? @open1 math_environment inline_formula displayed_equation)
+  (#set! conceal ""))
+
+(generic_command
+  command: (command_name) @_cmd (#eq? @_cmd "\\ket")
+  arg: (curly_group "}" @close1)
+  (#has-ancestor? @close1 math_environment inline_formula displayed_equation)
+  (#set! conceal "|"))

--- a/queries_config/latex/conceal_phy.scm
+++ b/queries_config/latex/conceal_phy.scm
@@ -5,7 +5,7 @@
   command: ((command_name) @cmd (#eq? @cmd "\\bra"))
   (#has-ancestor? @cmd math_environment inline_formula displayed_equation)
   (#set! priority 101)
-  (#set! conceal "|"))
+  (#set! conceal "<"))
 
 (generic_command
   command: (command_name) @_cmd (#eq? @_cmd "\\bra")
@@ -17,13 +17,13 @@
   command: (command_name) @_cmd (#eq? @_cmd "\\bra")
   arg: (curly_group "}" @close1)
   (#has-ancestor? @close1 math_environment inline_formula displayed_equation)
-  (#set! conceal ">"))
+  (#set! conceal "|"))
 
 (generic_command
   command: ((command_name) @cmd (#eq? @cmd "\\ket"))
   (#has-ancestor? @cmd math_environment inline_formula displayed_equation)
   (#set! priority 101)
-  (#set! conceal "<"))
+  (#set! conceal "|"))
 
 (generic_command
   command: (command_name) @_cmd (#eq? @_cmd "\\ket")
@@ -35,4 +35,4 @@
   command: (command_name) @_cmd (#eq? @_cmd "\\ket")
   arg: (curly_group "}" @close1)
   (#has-ancestor? @close1 math_environment inline_formula displayed_equation)
-  (#set! conceal "|"))
+  (#set! conceal ">"))


### PR DESCRIPTION
For example:
$\bra{a}$ -> <a|, $\ket{a}$ -> |a>